### PR TITLE
Be more verbose if the security token is missing / isn't obtained

### DIFF
--- a/PyXiaomiGateway/__init__.py
+++ b/PyXiaomiGateway/__init__.py
@@ -289,7 +289,7 @@ class XiaomiGateway(object):
             _LOGGER.debug('Gateway Token was not obtained yet. Cannot send commands to the gateway.')
             return False
         data['key'] = self._get_key()
-        cmd = []
+        cmd = {}
         cmd['cmd'] = 'write'
         cmd['sid'] = sid
         cmd['data'] = data

--- a/PyXiaomiGateway/__init__.py
+++ b/PyXiaomiGateway/__init__.py
@@ -280,15 +280,16 @@ class XiaomiGateway(object):
     def write_to_hub(self, sid, **kwargs):
         """Send data to gateway to turn on / off device"""
         if self.key is None:
-            _LOGGER.error('Gateway Key is not provided. Can not send commands to gateway.')
+            _LOGGER.error('Gateway Key is not provided. Can not send commands to the gateway.')
             return False
         data = {}
         for key in kwargs:
             data[key] = kwargs[key]
-        if self.token is None:
+        if not self.token:
+            _LOGGER.debug('Gateway Token was not obtained yet. Cannot send commands to the gateway.')
             return False
         data['key'] = self._get_key()
-        cmd = {}
+        cmd = []
         cmd['cmd'] = 'write'
         cmd['sid'] = sid
         cmd['data'] = data


### PR DESCRIPTION
https://community.home-assistant.io/t/xiaomi-gateway-integration-help-needed/28563/33

If a network doesn't support multicast traffic the heartbeat of the gateway doesn't arrive. In this case there is no "token" obtained and commands cannot be properly encrypted. Some users are reporting "invalid key" responses of the gateway. This would mean the token is populated properly(?) but the value is outdated(?). Could be packet loss. Does the gateway accept the most recent token only? Is there a window of valid tokens?