### PR TITLE
Fix compatibility with Python 2

### DIFF
--- a/PyXiaomiGateway/__init__.py
+++ b/PyXiaomiGateway/__init__.py
@@ -323,6 +323,8 @@ class XiaomiGateway(object):
         encryptor = Cipher(algorithms.AES(self.key.encode()), modes.CBC(init_vector),
                            backend=default_backend()).encryptor()
         ciphertext = encryptor.update(self.token.encode()) + encryptor.finalize()
+        if isinstance(ciphertext, str):  # For Python 2 compatibility
+            return ''.join('{:02x}'.format(ord(x)) for x in ciphertext)
         return ''.join('{:02x}'.format(x) for x in ciphertext)
 
 


### PR DESCRIPTION
ciphertext is str in Python 2 and bytes in Python 3. Reading from a
byte array in Python 3 returns an int but another str in Python 2.
For Python 2 this needs to be wrapped using ord().

See #34 