### PR TITLE
Explicit struct pack configuration

### DIFF
--- a/xiaomi_gateway/__init__.py
+++ b/xiaomi_gateway/__init__.py
@@ -121,7 +121,7 @@ class XiaomiGatewayDiscovery(object):
                 sock.bind((self.MULTICAST_ADDRESS, self.MULTICAST_PORT))
             else:
                 sock.bind(('', self.MULTICAST_PORT))
-            mreq = struct.pack("4sl", socket.inet_aton(self.MULTICAST_ADDRESS), socket.INADDR_ANY)
+            mreq = struct.pack("=4sl", socket.inet_aton(self.MULTICAST_ADDRESS), socket.INADDR_ANY)
 
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
         return sock


### PR DESCRIPTION
Alignment must be none. The native alignment of NetBSD doesn't work.

cp. https://community.home-assistant.io/t/xiaomi-gateway-not-discovered/25030/166
Thanks to errellion for pointing this out.

