### PR TITLE
Add Aqara button(WXKG11LM) another model name 'remote.b1acn01'

### DIFF
--- a/xiaomi_gateway/__init__.py
+++ b/xiaomi_gateway/__init__.py
@@ -242,7 +242,7 @@ class XiaomiGateway:
                        'weather.v1', 'sensor_motion.aq2', 'acpartner.v3', 'vibration'],
             'binary_sensor': ['magnet', 'sensor_magnet', 'sensor_magnet.aq2',
                               'motion', 'sensor_motion', 'sensor_motion.aq2',
-                              'switch', 'sensor_switch', 'sensor_switch.aq2', 'sensor_switch.aq3',
+                              'switch', 'sensor_switch', 'sensor_switch.aq2', 'sensor_switch.aq3', 'remote.b1acn01',
                               '86sw1', 'sensor_86sw1', 'sensor_86sw1.aq1',
                               '86sw2', 'sensor_86sw2', 'sensor_86sw2.aq1',
                               'cube', 'sensor_cube', 'sensor_cube.aqgl01',


### PR DESCRIPTION
I tried to add Aqara button(WXKG11LM) that has another model name 'remote.b1acn01', and got an error bottom.

> Unsupported device found! Please create an issue at https://github.com/Danielhiversen/PyXiaomiGateway/issues and provide the following data: {'cmd': 'read_ack', 'model': 'remote.b1acn01', 'sid': 'XXX', 'short_id': XXX, 'data': '{"voltage":XXX}'}
