### PR TITLE
Fix usage of uninitialized discovery_retries

### DIFF
--- a/xiaomi_gateway/__init__.py
+++ b/xiaomi_gateway/__init__.py
@@ -44,12 +44,11 @@ class XiaomiGatewayDiscovery:
         if self._interface != 'any':
             _socket.bind((self._interface, 0))
 
-        discovery_retries = DEFAULT_DISCOVERY_RETRIES
         for gateway in self._gateways_config:
             host = gateway.get('host')
             port = gateway.get('port')
             sid = gateway.get('sid')
-            discovery_retries = gateway.get('discovery_retries', discovery_retries)
+            discovery_retries = gateway.get('discovery_retries', DEFAULT_DISCOVERY_RETRIES)
 
             if not (host and port and sid):
                 continue
@@ -95,6 +94,7 @@ class XiaomiGatewayDiscovery:
                 for gateway in self._gateways_config:
                     sid = gateway.get('sid')
                     if sid is None or sid == resp["sid"]:
+                        discovery_retries = gateway.get('discovery_retries', DEFAULT_DISCOVERY_RETRIES)
                         gateway_key = gateway.get('key')
                     if sid and sid == resp['sid'] and gateway.get('disable'):
                         disabled = True


### PR DESCRIPTION
Sorry guys for doing it in two parts, however I've been thinking on it and in fact @syssi was right - it was not always providing proper value from the config. Now it looks much better. Could you check it @Danielhiversen ?

Also there's one thing worth considering - we added `discovery_retries` parameter to every gateway's configuration, while there's already `discovery_retry` parameter in main HA xiaomi_aqara config. So looks like we have "almost" name collision. Shouldn't we change the param name to something more descriptive? `device_discovery_retry` and in HA main config `gateway_discovery_retry`?