### PR TITLE
Increase recv buffer size from 1024 to 4096

### DIFF
--- a/xiaomi_gateway/__init__.py
+++ b/xiaomi_gateway/__init__.py
@@ -22,7 +22,7 @@ class XiaomiGatewayDiscovery:
     MULTICAST_ADDRESS = '224.0.0.50'
     MULTICAST_PORT = 9898
     GATEWAY_DISCOVERY_PORT = 4321
-    SOCKET_BUFSIZE = 10240
+    SOCKET_BUFSIZE = 4096
 
     def __init__(self, callback_func, gateways_config, interface,
                  device_discovery_retries=DEFAULT_DISCOVERY_RETRIES):
@@ -77,7 +77,7 @@ class XiaomiGatewayDiscovery:
                            (self.MULTICAST_ADDRESS, self.GATEWAY_DISCOVERY_PORT))
 
             while True:
-                data, (ip_add, _) = _socket.recvfrom(10240)
+                data, (ip_add, _) = _socket.recvfrom(self.SOCKET_BUFSIZE)
                 if len(data) is None or ip_add in self.gateways:
                     continue
 
@@ -311,7 +311,7 @@ class XiaomiGateway:
             _socket.settimeout(10.0)
             _LOGGER.debug("_send_cmd >> %s", cmd.encode())
             _socket.sendto(cmd.encode(), (self.ip_adress, self.port))
-            data, _ = _socket.recvfrom(10240)
+            data, _ = _socket.recvfrom(self.SOCKET_BUFSIZE)
         except socket.timeout:
             _LOGGER.error("Cannot connect to Gateway")
             return None

--- a/xiaomi_gateway/__init__.py
+++ b/xiaomi_gateway/__init__.py
@@ -14,6 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_DISCOVERY_RETRIES = 4
 
 GATEWAY_MODELS = ['gateway', 'gateway.v3', 'acpartner.v3']
+SOCKET_BUFSIZE = 4096
 
 
 class XiaomiGatewayDiscovery:
@@ -22,7 +23,6 @@ class XiaomiGatewayDiscovery:
     MULTICAST_ADDRESS = '224.0.0.50'
     MULTICAST_PORT = 9898
     GATEWAY_DISCOVERY_PORT = 4321
-    SOCKET_BUFSIZE = 4096
 
     def __init__(self, callback_func, gateways_config, interface,
                  device_discovery_retries=DEFAULT_DISCOVERY_RETRIES):
@@ -77,7 +77,7 @@ class XiaomiGatewayDiscovery:
                            (self.MULTICAST_ADDRESS, self.GATEWAY_DISCOVERY_PORT))
 
             while True:
-                data, (ip_add, _) = _socket.recvfrom(self.SOCKET_BUFSIZE)
+                data, (ip_add, _) = _socket.recvfrom(SOCKET_BUFSIZE)
                 if len(data) is None or ip_add in self.gateways:
                     continue
 
@@ -166,7 +166,7 @@ class XiaomiGatewayDiscovery:
         while self._listening:
             if self._mcastsocket is None:
                 continue
-            data, (ip_add, _) = self._mcastsocket.recvfrom(self.SOCKET_BUFSIZE)
+            data, (ip_add, _) = self._mcastsocket.recvfrom(SOCKET_BUFSIZE)
             try:
                 data = json.loads(data.decode("ascii"))
                 gateway = self.gateways.get(ip_add)
@@ -311,7 +311,7 @@ class XiaomiGateway:
             _socket.settimeout(10.0)
             _LOGGER.debug("_send_cmd >> %s", cmd.encode())
             _socket.sendto(cmd.encode(), (self.ip_adress, self.port))
-            data, _ = _socket.recvfrom(self.SOCKET_BUFSIZE)
+            data, _ = _socket.recvfrom(SOCKET_BUFSIZE)
         except socket.timeout:
             _LOGGER.error("Cannot connect to Gateway")
             return None

--- a/xiaomi_gateway/__init__.py
+++ b/xiaomi_gateway/__init__.py
@@ -22,7 +22,7 @@ class XiaomiGatewayDiscovery:
     MULTICAST_ADDRESS = '224.0.0.50'
     MULTICAST_PORT = 9898
     GATEWAY_DISCOVERY_PORT = 4321
-    SOCKET_BUFSIZE = 1024
+    SOCKET_BUFSIZE = 10240
 
     def __init__(self, callback_func, gateways_config, interface,
                  device_discovery_retries=DEFAULT_DISCOVERY_RETRIES):
@@ -77,7 +77,7 @@ class XiaomiGatewayDiscovery:
                            (self.MULTICAST_ADDRESS, self.GATEWAY_DISCOVERY_PORT))
 
             while True:
-                data, (ip_add, _) = _socket.recvfrom(1024)
+                data, (ip_add, _) = _socket.recvfrom(10240)
                 if len(data) is None or ip_add in self.gateways:
                     continue
 
@@ -311,7 +311,7 @@ class XiaomiGateway:
             _socket.settimeout(10.0)
             _LOGGER.debug("_send_cmd >> %s", cmd.encode())
             _socket.sendto(cmd.encode(), (self.ip_adress, self.port))
-            data, _ = _socket.recvfrom(1024)
+            data, _ = _socket.recvfrom(10240)
         except socket.timeout:
             _LOGGER.error("Cannot connect to Gateway")
             return None


### PR DESCRIPTION
I have so many devices under xiaomi_gateway. Error occur when homeassistant start discovery devices from xiaomi_gateway:

```
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.7/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 1010 (char 1009)
```

Increase the recv buffer size could fix this error.