### PR TITLE
Add support for WXKG06LM (remote.b186acn02)

### DIFF
--- a/xiaomi_gateway/__init__.py
+++ b/xiaomi_gateway/__init__.py
@@ -259,7 +259,7 @@ class XiaomiGateway:
             'binary_sensor': ['magnet', 'sensor_magnet', 'sensor_magnet.aq2',
                               'motion', 'sensor_motion', 'sensor_motion.aq2',
                               'switch', 'sensor_switch', 'sensor_switch.aq2', 'sensor_switch.aq3', 'remote.b1acn01',
-                              '86sw1', 'sensor_86sw1', 'sensor_86sw1.aq1', 'remote.b186acn01',
+                              '86sw1', 'sensor_86sw1', 'sensor_86sw1.aq1', 'remote.b186acn01', 'remote.b186acn02',
                               '86sw2', 'sensor_86sw2', 'sensor_86sw2.aq1', 'remote.b286acn01', 'remote.b286acn02',
                               'cube', 'sensor_cube', 'sensor_cube.aqgl01',
                               'smoke', 'sensor_smoke',


### PR DESCRIPTION
Even with the latest version of Home Assistant (0.115.3) which uses PyXiaomiGateway version 0.13.2, the support of Aqara D1 Wireless Remote Switch (Single Rocker) (WXKG06LM) (lumi.remote.b186acn02) still does not work. On startup you get:

```
Logger: xiaomi_gateway
Source: /usr/local/lib/python3.8/site-packages/xiaomi_gateway/__init__.py:309 
First occurred: 14:21:51 (3 occurrences) 
Last logged: 14:21:51

Unsupported device found! Please create an issue at https://github.com/Danielhiversen/PyXiaomiGateway/issues and provide the following data: {'cmd': 'read_ack', 'model': 'remote.b186acn02', 'sid': '158d0005441db0', 'short_id': 1075, 'data': '{"voltage":3115}'}
Unsupported device found! Please create an issue at https://github.com/Danielhiversen/PyXiaomiGateway/issues and provide the following data: {'cmd': 'read_ack', 'model': 'remote.b186acn02', 'sid': '158d00054418a2', 'short_id': 16642, 'data': '{"voltage":3115}'}
Unsupported device found! Please create an issue at https://github.com/Danielhiversen/PyXiaomiGateway/issues and provide the following data: {'cmd': 'read_ack', 'model': 'remote.b186acn02', 'sid': '158d0005220048', 'short_id': 4530, 'data': '{"voltage":3145}'}
```

I think this model has just been forgotten when those two commits were made:
https://github.com/Danielhiversen/PyXiaomiGateway/commit/88699a2ea3f06f258ed644f7acb9836df5e24249
and
https://github.com/Danielhiversen/PyXiaomiGateway/commit/f0742e12747d44ba353ba740bf796fadcbbae420

On the other side, it seems to be correctly referenced on HA side:
https://github.com/home-assistant/core/commit/3fc5f9deb82e855d69aa7001df96c5820a62554c

Fixes #185