### PR TITLE
Fix: multicast bind should be MULTICAST_ADDRESS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name = 'PyXiaomiGateway',
     packages = ['xiaomi_gateway'],
     install_requires=['cryptography>=2.1.1'],
-    version = '0.14.1',
+    version = '0.14.2',
     description = 'A library to communicate with the Xiaomi Gateway',
     author='Daniel Hjelseth Høyer',
     url='https://github.com/Danielhiversen/PyXiaomiGateway/',

--- a/xiaomi_gateway/__init__.py
+++ b/xiaomi_gateway/__init__.py
@@ -59,7 +59,7 @@ def create_mcast_socket(interface, port, bind_interface=True, blocking=True):
             socket.SOL_IP, socket.IP_ADD_MEMBERSHIP, mreq,
         )
 
-    udp_socket.bind((interface if bind_interface else "", port))
+    udp_socket.bind((MULTICAST_ADDRESS if bind_interface else "", port))
 
     return udp_socket
 


### PR DESCRIPTION
Fix: multicast bind should be MULTICAST_ADDRESS, it will be help in some environment

According to examples I found, lots of them indicate the binding address of muilticast should be the MULTICAST_GROUP instead of local address.
https://huichen-cs.github.io/course/CISC7334X/20FA/lecture/pymcast/#the-receiver-program-mcastrecvpy is one of them.

It helps solving issue like not receiving any message from XiaomiGateway. Tested and works in local home-assistant environment.